### PR TITLE
typo fix refer to the graph: 'name'->'new'

### DIFF
--- a/index-de.html
+++ b/index-de.html
@@ -391,7 +391,7 @@
 
   <p>
     Wenn du stattdessen diesen Zustand speichern möchtest, kannst du einen neuen Branch mit
-    <code>git checkout -b <em>name</em></code>
+    <code>git checkout -b <em>new</em></code>
     erstellen.
   </p>
 

--- a/index-en.html
+++ b/index-en.html
@@ -216,7 +216,7 @@
   <div class="center"><img src='checkout-after-detached.svg.png'></div>
 
   <p>If, on the other hand, you want to save this state, you can create a new
-  named branch using <code>git checkout -b <em>name</em></code>.</p>
+  named branch using <code>git checkout -b <em>new</em></code>.</p>
 
   <div class="center"><img src='checkout-b-detached.svg.png'></div>
 

--- a/index-it.html
+++ b/index-it.html
@@ -215,7 +215,7 @@
   <div class="center"><img src='checkout-after-detached.svg.png'></div>
 
   <p>Se, d'altronde, si volesse memorizzare questo stato, sarebbe necessario
-  creare un nuovo branch con nome utilizzando <code>git checkout -b <em>name</em></code>.</p>
+  creare un nuovo branch con nome utilizzando <code>git checkout -b <em>new</em></code>.</p>
 
   <div class="center"><img src='checkout-b-detached.svg.png'></div>
 

--- a/index-ja.html
+++ b/index-ja.html
@@ -135,7 +135,7 @@ Use this
 
   <div class="center"><img src='checkout-after-detached.svg.png'></div>
 
-  <p>逆にもし、この状態を保存したいなら、<code>git checkout -b <em>name</em></code> を使って、名前付きのブランチを新しく作ればよいのです。</p>
+  <p>逆にもし、この状態を保存したいなら、<code>git checkout -b <em>new</em></code> を使って、名前付きのブランチを新しく作ればよいのです。</p>
 
   <div class="center"><img src='checkout-b-detached.svg.png'></div>
 

--- a/index-vi.html
+++ b/index-vi.html
@@ -223,7 +223,7 @@
   <div class="center"><img src='checkout-after-detached.svg.png'></div>
 
   <p>Mặt khác nếu bạn muốn lưu trữ trạng thái này, bạn có thể tạo một nhánh mới
-  có tên cụ thể sử dụng lệnh <code>git checkout -b <em>name</em></code>.</p>
+  có tên cụ thể sử dụng lệnh <code>git checkout -b <em>new</em></code>.</p>
 
   <div class="center"><img src='checkout-b-detached.svg.png'></div>
 

--- a/index-zh-cn.html
+++ b/index-zh-cn.html
@@ -154,7 +154,7 @@
 
   <div class="center"><img src='checkout-after-detached.svg.png'></div>
 
-  <p>但是，如果你想保存这个状态，可以用命令<code>git checkout -b <em>name</em></code>来创建一个新的分支。</p>
+  <p>但是，如果你想保存这个状态，可以用命令<code>git checkout -b <em>new</em></code>来创建一个新的分支。</p>
 
   <div class="center"><img src='checkout-b-detached.svg.png'></div>
 


### PR DESCRIPTION
According to the 3rd figure of "Committing with a Detached HEAD" section, here is a typo.

fixed with

```
sed -i -e 's/<code>git checkout -b <em>name<\/em>/<code>git checkout -b <em>new<\/em>/g' *.html
```
