### PR TITLE
fix basic usage svg

### DIFF
--- a/basic-usage.tex
+++ b/basic-usage.tex
@@ -15,10 +15,10 @@
             edge node[cmd] {git commit}
         (head.south east)
         (index.south west)
-            edge node[cmd] {git checkout -- \emph{files}}
+            edge node[cmd] {git reset --soft HEAD~1}
         (work.north west)
         (head.south west)
-            edge node[cmd] {git reset -- \emph{files}}
+            edge node[cmd] {git checkout -- \emph{files}}
         (index.north west)
         ;
 \end{tikzpicture}


### PR DESCRIPTION
I think there is a mistake in the commands used to bring changes from **History** to **Staging Area** and from **Staging Area** to **Working Directory.

Here is a little summary to go from one zone to another one between HEAD (or History), Index (or Staging Area) and Working Directory.

| From       | Command                       | To       |
| :------------------- | :----------------------------: | -------------------: |
| Working Directory    | `git add <file>...`            | Index                |
| Index                | `git commit <file>...`         | HEAD                 |
| HEAD                 | `git reset --soft HEAD~1`      | Index                |
| Index                | `git reset HEAD <file>...`     | Working Directory    |
| Working Directory    | `git commit -a`                | HEAD    |
| HEAD                 | `git reset HEAD~1`             | Working Directory    |

What do you think?